### PR TITLE
logo_url と favicon_url のパスを調整

### DIFF
--- a/sphinx_shiguredo_theme/layout.html
+++ b/sphinx_shiguredo_theme/layout.html
@@ -33,7 +33,7 @@
     title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"
     href="/{{ pathto('_static/opensearch.xml', 1) }}" />
   {%- endif %} {%- if favicon_url %}
-  <link rel="shortcut icon" href="/{{ pathto('_static/' + favicon_url, 1)|e }}" />
+  <link rel="shortcut icon" href="/{{ favicon_url|e }}" />
   {%- endif %} {%- endif %} {%- block linktags %} {%- if hasdoc('about') %}
   <link rel="author" title="{{ _('About these documents') }}" href="{{ pathto('about') }}" />
   {%- endif %} {%- if hasdoc('genindex') %}

--- a/sphinx_shiguredo_theme/layout.html
+++ b/sphinx_shiguredo_theme/layout.html
@@ -66,7 +66,7 @@
             <div class="left-sidenavi-header-logo">
               {%- if logo_url %}
               <div>
-                <img class="logo" src="/{{ pathto('_static/' + logo_url, 1)|e }}" alt="Logo" />
+                <img class="logo" src="{{  logo_url|e }}" alt="Logo" />
               </div>
               {%- endif %}
             </div>


### PR DESCRIPTION
Sphinx-4.0 から導入された `logo_url` は _static ディレクトリを含む、 ロゴファイルへの相対パスを返すようになっているため、HTML テンプレート上
ではパスの組み立てを行う必要がなくなった。

それに合わせ、単に URL を埋め込むだけに変更する。