### PR TITLE
ソースコードではないファイルを配布物に含める設定を追加

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft sphinx_shiguredo_theme

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,23 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 setup(
     name='sphinx_shiguredo_theme',
     version='2022.1.0',
-    packages=find_packages('sphinx_shiguredo_theme'),
+    packages=find_namespace_packages(
+        include=['sphinx_shiguredo_theme', 'sphinx_shiguredo_theme.*']
+    ),
     entry_points={
         'sphinx.html_themes': [
             'sphinx_shiguredo_theme = sphinx_shiguredo_theme',
         ]
-    }
+    },
+    include_package_data=True,
+    package_data={
+        'sphinx_shiguredo_theme': [
+            'theme.conf',
+            '*.html',
+            'static/css/*.css',
+            'static/js/*.js',
+        ]
+    },
 )


### PR DESCRIPTION
試行錯誤した結果、この設定内容で rye add + rye sync によるインストールが成功（※）することを確認しました。
（※）ここでいう成功とは *.py 以外のファイル（html や css など）が期待通りインストールされることを指します。