### PR TITLE
style 変数は 7.0.0 で廃止。代わりに styles を使う

### DIFF
--- a/sphinx_shiguredo_theme/layout.html
+++ b/sphinx_shiguredo_theme/layout.html
@@ -4,7 +4,7 @@
 '' %}{% endif %} {%- macro css() %}
 <link rel="stylesheet" href="/{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
 <link rel="stylesheet" href="/{{ pathto('_static/basic.css', 1) }}" type="text/css" />
-<link rel="stylesheet" href="/{{ pathto('_static/' + style, 1)|e }}" type="text/css" />
+<link rel="stylesheet" href="/{{ pathto('_static/' + styles[-1], 1)|e }}" type="text/css" />
 {%- for css in css_files %} {%- if css|attr("filename") %} {{ css_tag(css) }}
 {%- else %}
 <link rel="stylesheet" href="{{ pathto(css, 1)|e }}" type="text/css" />


### PR DESCRIPTION
Sphinx 7.x 系で theme のビルドエラーが出ますが、この修正で解決します。

- https://www.sphinx-doc.org/en/master/changes.html#release-7-0-0-released-apr-29-2023
- https://github.com/sphinx-doc/sphinx/pull/11381