### PR TITLE
mermaid のレンダリングが非同期で行われ、アンカー位置が当初とずれてしまうのを補正する

### DIFF
--- a/sphinx_shiguredo_theme/static/js/theme.js
+++ b/sphinx_shiguredo_theme/static/js/theme.js
@@ -61,6 +61,7 @@
     if (locationHash === "") {
         return;
     }
+
     // アンカーが実在することを確認しておく
     const anchor = document.getElementById(locationHash.slice(1));  // 先頭の # を除去
     if (anchor === null) {
@@ -68,6 +69,9 @@
     }
 
     const mermaidNodes = [...document.querySelectorAll("div.mermaid")];
+    if (mermaidNodes.length === 0) {
+        return;
+    }
 
     // すべての mermaid 要素のレンダリングが完了したら、ずれを補正するため
     // もう一度 anchor 位置に移動する。


### PR DESCRIPTION
ページ内のすべての mermaid の要素がレンダリングされたのを検知し、location.replace() で新しいアンカー位置にフォーカスします。
変更検知には MutationObserver API を使用します。
mermaid の要素がひとつもない場合は何もしません。