### PR TITLE
hash-based node id を使用しないオプションを導入する

### DIFF
--- a/sphinx_shiguredo_theme/__init__.py
+++ b/sphinx_shiguredo_theme/__init__.py
@@ -1,13 +1,29 @@
 from collections import defaultdict
 from hashlib import sha1
 from os import path
-import re
 
 from docutils import nodes
 from sphinx.transforms.post_transforms import SphinxPostTransform
 
 
 def on_doctree_resolved(app, doctree, docname):
+    # TODO theme の __init__.py 内部で theme.conf の設定値を参照するベストの方法が
+    # 下記で合っているかどうかは不明。
+
+    # conf.py の設定があればそちらを優先する
+    if "use_hash_based_nodeid" in app.config.html_theme_options:
+        use_hash_based_nodeid = app.config.html_theme_options["use_hash_based_nodeid"]
+    else:
+        theme_options = app.builder.theme.get_options()
+        _use_hash_based_nodeid = theme_options.get("use_hash_based_nodeid")
+        if isinstance(_use_hash_based_nodeid, str):
+            use_hash_based_nodeid = _use_hash_based_nodeid.lower() == "true"
+        else:
+            use_hash_based_nodeid = bool(_use_hash_based_nodeid)
+
+    if not use_hash_based_nodeid:
+        return
+
     # add hash-based node-ID to sections
     mapping = {}
     sequences = defaultdict(int)

--- a/sphinx_shiguredo_theme/theme.conf
+++ b/sphinx_shiguredo_theme/theme.conf
@@ -6,6 +6,8 @@ pygments_style = default
 [options]
 left_sidenavi_header_bgcolor =
 attention_message =
+# 現行の挙動を default とする
+use_hash_based_nodeid = True
 meilisearch = False
 meilisearch_api_key =
 meilisearch_host_url =


### PR DESCRIPTION
`py:class` などのディレクティブを使用すると hash-based node id ではリンクが意図したものにならない。
hash-based node id 自体は何か意図があって導入されたものと思うので、その機能自体は維持しておき、使用するかどうかをオプションで決定できるようにする。

`use_hash_based_nodeid` default: `True` (現行の挙動)
`False` を設定すると node id を hash based にする置換操作を行わない。